### PR TITLE
fix ImageMath invocation: prefixed missing $ANTSPATH

### DIFF
--- a/LASHiS.sh
+++ b/LASHiS.sh
@@ -502,8 +502,8 @@ fi
 SINGLE_SUBJECT_TEMPLATE=${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template0_rescaled.nii.gz
 if [[ ! -f ${SINGLE_SUBJECT_TEMPLATE} ]]; then 
     #Rescale the images because ASHS can't handle float for some reason
-    logCmd ImageMath 3 ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template1_rescaled.nii.gz RescaleImage ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template1.nii.gz 0 1000 
-    logCmd ImageMath 3 ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template0_rescaled.nii.gz RescaleImage ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template0.nii.gz 0 1000
+    logCmd ${ANTSPATH}/ImageMath 3 ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template1_rescaled.nii.gz RescaleImage ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template1.nii.gz 0 1000
+    logCmd ${ANTSPATH}/ImageMath 3 ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template0_rescaled.nii.gz RescaleImage ${OUTPUT_DIRECTORY_FOR_SINGLE_SUBJECT_TEMPLATE}T_template0.nii.gz 0 1000
     
 fi
 ###############################


### PR DESCRIPTION
fixes:
```
[...]
User Linear interpolation
 You are doing something more complex -- we wont check syntax in this case
output origin: [89.996, 101.645, -119.845]
output size: [202, 266, 266]
output spacing: [0.9, 0.898438, 0.898438]
output direction: -0.999903 0 0.0139622
0 -1 0
0.0139622 0 0.999903


--------------------------------------------------------------------------------------
 Done creating: S012SingleSubjectTemplate/T_template0.nii.gz S012SingleSubjectTemplate/T_template1.nii.gz
 Script executed in 11605 seconds
 3h 13m 25s
--------------------------------------------------------------------------------------
Command finished without error!


Start command:
ImageMath 3 S012SingleSubjectTemplate/T_template1_rescaled.nii.gz RescaleImage S012SingleSubjectTemplate/T_template1.nii.gz 0 1000 [...]/LASHiS.sh: line 175: ImageMath: command not found
ERROR: command exited with nonzero status 127
Command: ImageMath 3 S012SingleSubjectTemplate/T_template1_rescaled.nii.gz RescaleImage S012SingleSubjectTemplate/T_template1.nii.gz 0 1000
```