### PR TITLE
fix script dependencies check: loop over undefined variable

### DIFF
--- a/LASHiS.sh
+++ b/LASHiS.sh
@@ -27,7 +27,7 @@
 # Check dependencies
 
 PROGRAM_DEPENDENCIES=( 'antsApplyTransforms' 'N4BiasFieldCorrection' )
-SCRIPTS_DEPENDENCIES=( 'antsBrainExtraction.sh' 'antsMultivariateTemplateConstruction2.sh' 'antsJointLabelFusion2.sh' )
+SCRIPT_DEPENDENCIES=( 'antsBrainExtraction.sh' 'antsMultivariateTemplateConstruction2.sh' 'antsJointLabelFusion2.sh' )
 ASHS_DEPENDENCIES=( '/bin/ashs_main.sh' '/ext/Linux/bin/c3d' )
 
 for D in ${PROGRAM_DEPENDENCIES[@]};


### PR DESCRIPTION
fix for variable name mismatch

`$SCRIPTS_DEPENDENCIES` vs. `$SCRIPT_DEPENDENCIES`

```sh
[...]
SCRIPTS_DEPENDENCIES=( 'antsBrainExtraction.sh' 'antsMultivariateTemplateConstruction2.sh' 'antsJointLabelFusion2.sh' )
[...]
for D in ${SCRIPT_DEPENDENCIES[@]};
[...]
```
