### PR TITLE
readme: added version constraint for ANTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ Longitudinal Automatic Segmentation of Hippocampal Subfields (LASHiS) using mult
 
 ## Requirements:
 
- Requires ANTs  https://github.com/ANTsX/ANTs/
- Requires ASHS https://sites.google.com/site/hipposubfields/home 
+ Requires ANTs  https://github.com/ANTsX/ANTs/ (>= v2.3.0)
+
+ Requires ASHS https://sites.google.com/site/hipposubfields/home
 
 LASHiS performs a longitudinal estimation of hippoocampus subfields.  The following steps are performed:
   1. Run Cross-sectional ASHS on all timepoints


### PR DESCRIPTION
`antsJointLabelFusion2.sh` was added in ANTs v2.3.0

https://github.com/ANTsX/ANTs/commit/5acfa5a1a0dee40c43f56f99e29d35a5b106c1b7

A note informing users about this version constraint might be useful.

My environment had an older version installed

